### PR TITLE
Enable split RawHID relay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,16 @@ if (CONFIG_RAW_HID)
   zephyr_library()
 
   zephyr_library_sources(src/events.c)
-  zephyr_library_sources(src/usb_hid.c)
+  if (NOT CONFIG_ZMK_SPLIT OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    zephyr_library_sources(src/usb_hid.c)
 
-  if (CONFIG_ZMK_BLE)
-    zephyr_library_sources(src/hog.c)
+    if (CONFIG_ZMK_BLE)
+      zephyr_library_sources(src/hog.c)
+    endif()
+  endif()
+
+  if (CONFIG_ZMK_SPLIT && CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    zephyr_library_sources(src/raw_hid_split_bridge.c)
   endif()
 
   zephyr_include_directories(include)

--- a/Kconfig
+++ b/Kconfig
@@ -1,6 +1,5 @@
 config RAW_HID
     bool "Enable Raw HID"
-    depends on !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
     imply USB_DEVICE_HID
 
 config RAW_HID_USAGE_PAGE
@@ -18,3 +17,7 @@ config RAW_HID_REPORT_SIZE
 config RAW_HID_DEVICE
     string "Raw HID Device"
     default HID_1
+
+config RAW_HID_SPLIT_CHANNEL
+    int "Raw HID Split Relay Channel"
+    default 1

--- a/src/raw_hid_split_bridge.c
+++ b/src/raw_hid_split_bridge.c
@@ -1,0 +1,33 @@
+#include <raw_hid/events.h>
+#include <zmk/split/output-relay/event.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+static int raw_hid_bridge_listener(const zmk_event_t *eh) {
+    struct raw_hid_received_event *ev = as_raw_hid_received_event(eh);
+    if (!ev) {
+        return ZMK_EV_EVENT_BUBBLE;
+    }
+
+    struct zmk_split_bt_output_relay_event relay = {
+        .relay_channel = CONFIG_RAW_HID_SPLIT_CHANNEL,
+        .value = 0,
+        .payload_size = ev->length,
+    };
+    if (relay.payload_size > CONFIG_ZMK_SPLIT_OUTPUT_RELAY_MAX_PAYLOAD_SIZE) {
+        relay.payload_size = CONFIG_ZMK_SPLIT_OUTPUT_RELAY_MAX_PAYLOAD_SIZE;
+    }
+    memcpy(relay.payload, ev->data, relay.payload_size);
+
+    const struct device *dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(now_playing_dev));
+    if (dev) {
+        zmk_split_bt_invoke_output(dev, relay);
+    }
+
+    return ZMK_EV_EVENT_BUBBLE;
+}
+
+ZMK_LISTENER(raw_hid_split_bridge, raw_hid_bridge_listener);
+ZMK_SUBSCRIPTION(raw_hid_split_bridge, raw_hid_received_event);


### PR DESCRIPTION
## Summary
- add payload support to split output relay service
- allow RawHID on peripherals and send reports to split channel
- raise RawHID events on peripheral to feed nice!view widget

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68824609a8c88321b63c53ba8e280894