### PR TITLE
docs: expand split relay instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,16 @@ if (CONFIG_RAW_HID)
   zephyr_library()
 
   zephyr_library_sources(src/events.c)
-  zephyr_library_sources(src/usb_hid.c)
+  if (NOT CONFIG_ZMK_SPLIT OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    zephyr_library_sources(src/usb_hid.c)
 
-  if (CONFIG_ZMK_BLE)
-    zephyr_library_sources(src/hog.c)
+    if (CONFIG_ZMK_BLE)
+      zephyr_library_sources(src/hog.c)
+    endif()
+  endif()
+
+  if (CONFIG_ZMK_SPLIT AND CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    zephyr_library_sources(src/raw_hid_split_bridge.c)
   endif()
 
   zephyr_include_directories(include)

--- a/Kconfig
+++ b/Kconfig
@@ -1,6 +1,5 @@
 config RAW_HID
     bool "Enable Raw HID"
-    depends on !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
     imply USB_DEVICE_HID
 
 config RAW_HID_USAGE_PAGE
@@ -18,3 +17,20 @@ config RAW_HID_REPORT_SIZE
 config RAW_HID_DEVICE
     string "Raw HID Device"
     default HID_1
+
+config RAW_HID_SPLIT_CHANNEL
+    int "Raw HID Split Relay Channel"
+    default 1
+
+choice
+    prompt "Output relay length field"
+    depends on RAW_HID && ZMK_SPLIT
+    default RAW_HID_OUTPUT_RELAY_FIELD_PAYLOAD_LEN
+
+config RAW_HID_OUTPUT_RELAY_FIELD_PAYLOAD_LEN
+    bool "payload_len"
+
+config RAW_HID_OUTPUT_RELAY_FIELD_PAYLOAD_SIZE
+    bool "payload_size"
+
+endchoice

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ manifest:
     - name: zmk-raw-hid # <-- new entry
       remote: zzeneg
       revision: main
+    - name: zmk-split-peripheral-output-relay # for split forwarding
+      remote: zzeneg
+      revision: peripheral
+    - name: zmk-nice-view-hid # display widget
+      remote: zzeneg
+      revision: peripheral-2
   self:
     path: config
 ```
@@ -44,6 +50,60 @@ include:
   - board: nice_nano_v2
     shield: molekula raw_hid_adapter
 ```
+
+### Forward Raw HID data to split peripherals
+
+To relay Raw HID packets over the ZMK split link, define an output relay device
+in the left/central `board.overlay` and reference it from the right/peripheral
+overlay. The relay channel must match the `CONFIG_RAW_HID_SPLIT_CHANNEL` option
+(defaults to `1`). An example configuration is shown below:
+
+```dts
+/* board_left.overlay - central */
+/ {
+    now_playing_dev: now_playing_dev {
+        compatible = "zmk,output-split-output-relay";
+        #binding-cells = <0>;
+    };
+
+    now_playing_relay: now_playing_relay {
+        compatible = "zmk,split-peripheral-output-relay";
+        device = <&now_playing_dev>;
+        relay-channel = <1>; /* must match CONFIG_RAW_HID_SPLIT_CHANNEL */
+    };
+};
+
+/* board_right.overlay - peripheral */
+/ {
+    now_playing_dev: now_playing_dev {
+        compatible = "zmk,output-split-output-relay";
+        #binding-cells = <0>;
+    };
+
+    now_playing_relay: now_playing_relay {
+        compatible = "zmk,split-peripheral-output-relay";
+        device = <&now_playing_dev>;
+        relay-channel = <1>;
+    };
+};
+```
+
+Ensure these nodes are defined at the root of each overlay. Do **not** place
+them under `&split_central` or `&split_peripheral` as those nodes are not
+standalone and will cause an "undefined node label 'split'" error.
+
+Depending on the version of `zmk-split-peripheral-output-relay` in use, the
+relay event structure may expose the length field as `payload_len` or
+`payload_size`. Select the matching option via
+`CONFIG_RAW_HID_OUTPUT_RELAY_FIELD_PAYLOAD_LEN` or
+`CONFIG_RAW_HID_OUTPUT_RELAY_FIELD_PAYLOAD_SIZE`.
+
+When the central half receives Raw HID data (for example from
+`qmk-hid-host`), the module will forward the payload over the `now_playing_dev`
+relay device. On the peripheral side the
+`zmk-split-peripheral-output-relay` module converts the message into a
+`raw_hid_received_event`, which can be consumed by widgets such as
+`zmk-nice-view-hid` to show artist and track information.
 
 ## Adding support in other modules
 
@@ -72,6 +132,9 @@ ZMK_SUBSCRIPTION(process_raw_hid_event, raw_hid_received_event);
 | `CONFIG_RAW_HID_USAGE`       | HID Usage                         | 0x61    |
 | `CONFIG_RAW_HID_REPORT_SIZE` | HID Report size (number of bytes) | 32      |
 | `CONFIG_RAW_HID_DEVICE`      | New HID device name               | HID_1   |
+| `CONFIG_RAW_HID_SPLIT_CHANNEL` | Output relay channel for Raw HID  | 1       |
+| `CONFIG_RAW_HID_OUTPUT_RELAY_FIELD_PAYLOAD_LEN` | Relay struct uses `payload_len` | y |
+| `CONFIG_RAW_HID_OUTPUT_RELAY_FIELD_PAYLOAD_SIZE` | Relay struct uses `payload_size` | n |
 
 ## Thanks
 

--- a/src/raw_hid_split_bridge.c
+++ b/src/raw_hid_split_bridge.c
@@ -1,0 +1,45 @@
+#include <raw_hid/events.h>
+#include <zmk/split/output-relay/event.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+#if IS_ENABLED(CONFIG_RAW_HID_OUTPUT_RELAY_FIELD_PAYLOAD_SIZE)
+#define RELAY_SIZE_FIELD payload_size
+#elif IS_ENABLED(CONFIG_RAW_HID_OUTPUT_RELAY_FIELD_PAYLOAD_LEN)
+#define RELAY_SIZE_FIELD payload_len
+#else
+#error "RAW_HID output relay field not configured"
+#endif
+
+static int raw_hid_bridge_listener(const zmk_event_t *eh) {
+    struct raw_hid_received_event *ev = as_raw_hid_received_event(eh);
+    if (!ev) {
+        return ZMK_EV_EVENT_BUBBLE;
+    }
+
+    struct zmk_split_bt_output_relay_event relay = {
+        .relay_channel = CONFIG_RAW_HID_SPLIT_CHANNEL,
+        .RELAY_SIZE_FIELD = ev->length,
+    };
+#ifdef MAX_PAYLOAD_LEN
+    if (relay.RELAY_SIZE_FIELD > MAX_PAYLOAD_LEN) {
+        relay.RELAY_SIZE_FIELD = MAX_PAYLOAD_LEN;
+    }
+    memcpy(relay.payload, ev->data, relay.RELAY_SIZE_FIELD);
+#else
+    ARG_UNUSED(relay);
+    ARG_UNUSED(ev);
+#endif
+
+    const struct device *dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(now_playing_dev));
+    if (dev) {
+        zmk_split_bt_invoke_output(dev, relay);
+    }
+
+    return ZMK_EV_EVENT_BUBBLE;
+}
+
+ZMK_LISTENER(raw_hid_split_bridge, raw_hid_bridge_listener);
+ZMK_SUBSCRIPTION(raw_hid_split_bridge, raw_hid_received_event);


### PR DESCRIPTION
## Summary
- outline additional modules needed for forwarding RawHID data
- show full overlay example with split relay nodes at the root
- document `CONFIG_RAW_HID_SPLIT_CHANNEL`
- allow selecting the output relay field name
- handle `payload_len` vs `payload_size` in the split bridge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68824609a8c88321b63c53ba8e280894