### PR TITLE
Fix runtime device lookup

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -18,6 +18,10 @@ config RAW_HID_DEVICE
     string "Raw HID Device"
     default HID_1
 
+config RAW_HID_OUTPUT_RELAY_DEVICE
+    string "Raw HID Output Relay Device"
+    default "nice_view_adapter"
+
 config RAW_HID_SPLIT_CHANNEL
     int "Raw HID Split Relay Channel"
     default 1

--- a/boards/shields/raw_hid_adapter/raw_hid_adapter.overlay
+++ b/boards/shields/raw_hid_adapter/raw_hid_adapter.overlay
@@ -1,0 +1,15 @@
+/
+{
+    nice_view_adapter: nice_view_adapter {
+        status = "okay";
+        compatible = "zmk,output-split-output-relay";
+        #binding-cells = <0>;
+    };
+
+    nice_view_adapter_cfg: nice_view_adapter_cfg {
+        status = "okay";
+        compatible = "zmk,split-peripheral-output-relay";
+        device = <&nice_view_adapter>;
+        relay-channel = <1>;
+    };
+};

--- a/src/raw_hid_split_bridge.c
+++ b/src/raw_hid_split_bridge.c
@@ -33,8 +33,7 @@ static int raw_hid_bridge_listener(const zmk_event_t *eh) {
     ARG_UNUSED(ev);
 #endif
 
-const struct device *dev =
-    DEVICE_DT_GET_OR_NULL(DT_NODELABEL(nice_view_adapter));
+    const struct device *dev = device_get_binding(CONFIG_RAW_HID_OUTPUT_RELAY_DEVICE);
     if (dev) {
         zmk_split_bt_invoke_output(dev, relay);
     }


### PR DESCRIPTION
## Summary
- add configurable RAW_HID_OUTPUT_RELAY_DEVICE
- lookup relay device using config string
- provide board overlay nodes for the output relay

## Testing
- `pip install --user west`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68836aaf86408321be9f825f37414b10